### PR TITLE
refactor: Remove TTL extension side-effect from view function get_tips()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,7 +595,6 @@ impl TipContract {
         for i in start..end {
             let key = DataKey::Tip(creator.clone(), i);
             if let Some(tip) = env.storage().persistent().get(&key) {
-                extend_persistent_ttl(&env, &key);
                 results.push_back(tip);
             }
         }


### PR DESCRIPTION
Resolves StellarTips/StellarTip-Contract#30

### Overview
This PR removes the `extend_persistent_ttl` side-effect from the `get_tips()` view function in `src/lib.rs`.

### Details
- **Gas Cost Reduction**: `get_tips()` is meant to be a read-only view function. Previously, calling `extend_persistent_ttl` inside the pagination loop triggered state modifications, causing unexpected and linearly growing gas costs for callers based on the `limit` parameter.
- **State Modification Removed**: We've removed this call to adhere strictly to the principle that view functions must be read-only.
- **TTL Safely Handled**: The `tip()` function already correctly extends the TTL at write time when the tip records are created, so there are no negative side-effects regarding data retention. 

### Testing and Verification
- All existing unit tests pass successfully, confirming that `get_tips()` continues to return the correct tip data without any functional changes.
- Checked with `cargo clippy -D warnings` to ensure a clean build.