### PR TITLE
fix: emit EVENT_INIT event in init()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,9 @@ const EVENT_ADMIN_CHANGED: Symbol = soroban_sdk::symbol_short!("ADMC");
 /// Emitted when the fee recipient is changed.
 const EVENT_FEE_RECIPIENT_CHANGED: Symbol = soroban_sdk::symbol_short!("FERC");
 
+/// Emitted when the contract is initialized.
+const EVENT_INIT: Symbol = soroban_sdk::symbol_short!("INIT");
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -210,6 +213,7 @@ impl TipContract {
         env.storage().instance().set(&DataKey::FeeBps, &fee_bps);
         env.storage().instance().set(&DataKey::Paused, &false);
         extend_instance_ttl(&env);
+        env.events().publish((EVENT_INIT, caller), (fee_recipient, fee_bps));
     }
 
     // -----------------------------------------------------------------------

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,10 +1,10 @@
 #![cfg(test)]
 
 use soroban_sdk::{
-    testutils::{Address as _, Ledger, LedgerInfo},
+    testutils::{Address as _, Events, Ledger, LedgerInfo},
     token,
     token::StellarAssetClient,
-    Address, Env, String, Symbol,
+    Address, Env, String, Symbol, TryIntoVal,
 };
 use token::Client as TokenClient;
 
@@ -147,6 +147,64 @@ fn test_init_sets_admin_and_fee() {
 fn test_init_twice_fails() {
     let t = TestEnv::new();
     t.tip_client().init(&t.admin, &t.fee_recipient, &0u32);
+}
+
+#[test]
+fn test_init_emits_event() {
+    // Use a dedicated env so we can inspect emitted events directly,
+    // independent of the shared TestEnv construction path.
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set(LedgerInfo {
+        timestamp: 1000,
+        protocol_version: 22,
+        sequence_number: 100,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 1_000_000,
+        min_temp_entry_ttl: 10,
+    });
+
+    let admin = Address::generate(&env);
+    let fee_recipient = Address::generate(&env);
+    let contract_id = env.register(TipContract, ());
+    let client = crate::TipContractClient::new(&env, &contract_id);
+
+    // Non-default fee bps so the payload cannot accidentally be zero.
+    client.init(&admin, &fee_recipient, &500u32);
+
+    let events = env.events().all();
+    let expected_name = Symbol::new(&env, "INIT");
+
+    // Exactly one EVENT_INIT event should be published, with the admin as
+    // topic[1] and (fee_recipient, fee_bps = 500) as the payload.
+    let mut total: u32 = 0;
+    let mut init_event = None;
+    for event in &events {
+        let topics = &event.1;
+        if topics.len() < 2 {
+            continue;
+        }
+        if let Some(topic0) = topics.get(0) {
+            let sym: Symbol = topic0.try_into_val(&env).unwrap();
+            if sym == expected_name {
+                total += 1;
+                init_event = Some(event);
+            }
+        }
+    }
+    assert_eq!(total, 1, "expected exactly one EVENT_INIT, found {total}");
+
+    let event = init_event.unwrap();
+    assert_eq!(event.0, contract_id);
+
+    let topic_admin: Address = event.1.get(1).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(topic_admin, admin);
+
+    let (payload_recipient, payload_bps): (Address, u32) = event.2.try_into_val(&env).unwrap();
+    assert_eq!(payload_recipient, fee_recipient);
+    assert_eq!(payload_bps, 500);
 }
 
 #[test]

--- a/test_snapshots/test/test_init_emits_event.1.json
+++ b/test_snapshots/test/test_init_emits_event.1.json
@@ -1,0 +1,213 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "init",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 500
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 10,
+    "min_temp_entry_ttl": 10,
+    "max_entry_ttl": 1000000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          1000099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "FeeBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "FeeRecipient"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518500
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          518500
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000003",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "INIT"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 500
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The `init()` function in `src/lib.rs` previously did not emit any event, breaking observability consistency with every other state-changing function. This PR adds an `EVENT_INIT` event published at the end of `init()`, plus a dedicated test that asserts the event is emitted with the correct topic and payload.

## Changes

- **`src/lib.rs`**: Added a new `EVENT_INIT` Symbol constant alongside the existing `EVENT_*` constants, and emit it from `init()` with topic `(EVENT_INIT, caller)` and payload `(fee_recipient, fee_bps)`, matching the conventions used by `set_admin`, `set_fee_percentage`, `set_fee_recipient`, etc.
- **`src/test.rs`**: Added a new `test_init_emits_event` that initializes the contract with a non-default fee bps (500), then iterates `env.events().all()` to assert exactly one event with topic[0] == `INIT`, topic[1] == admin, and payload == `(fee_recipient, 500u32)`. New imports: `testutils::Events` (to access `env.events().all()`) and `TryIntoVal` (to decode `Val` topics/payload).
- **`test_snapshots/test/test_init_emits_event.1.json`**: Auto-generated snapshot capturing the emitted `INIT` event with topics `["INIT", admin_address]` and data `[fee_recipient_address, 500u32]`.

## Testing

All checks pass locally with the CI-exact toolchain (nightly, target `wasm32-unknown-unknown`):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --target wasm32-unknown-unknown --release -- -D warnings` — clean
- `cargo test` — 38 / 38 tests passing
- `cargo build --release --target wasm32-unknown-unknown` — artifact produced (`stellar_tip.wasm`, ~19K)

Closes #31