### PR TITLE
Prevent fee-routing loop: reject fee_recipient == contract address

### DIFF
--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -41,7 +41,7 @@ impl FuzzEnv {
 
         let admin = Address::generate(&env);
         let fee_recipient = Address::generate(&env);
-        let contract_id = env.register(TipContract, ());
+        let contract_id = env.register_contract(None, TipContract);
 
         let token_admin = Address::generate(&env);
         let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,6 +285,9 @@ impl TipContract {
         if min_tip_amount < 0 {
             panic_with_error!(env, TipError::InvalidInput);
         }
+        if fee_recipient == env.current_contract_address() {
+            panic_with_error!(env, TipError::InvalidInput);
+        }
         env.storage().instance().set(&DataKey::Admin, &caller);
         env.storage().instance().set(&DataKey::FeeRecipient, &fee_recipient);
         env.storage().instance().set(&DataKey::FeeBps, &fee_bps);
@@ -378,6 +381,9 @@ impl TipContract {
             .unwrap_or_else(|| panic_with_error!(env, TipError::NotInitialized));
         if caller != admin {
             panic_with_error!(env, TipError::NotAuthorized);
+        }
+        if fee_recipient == env.current_contract_address() {
+            panic_with_error!(env, TipError::InvalidInput);
         }
         env.storage().instance().set(&DataKey::FeeRecipient, &fee_recipient);
         extend_instance_ttl(&env);

--- a/src/test.rs
+++ b/src/test.rs
@@ -207,6 +207,46 @@ fn test_init_twice_fails() {
 }
 
 #[test]
+#[should_panic(expected = "#12")]
+fn test_init_fee_recipient_is_contract_address() {
+    let env: Env = Env::default();
+    env.mock_all_auths();
+
+    // Advance the ledger so timestamps are > 0.
+    env.ledger().set(LedgerInfo {
+        timestamp: 1000,
+        protocol_version: 22,
+        sequence_number: 100,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 1_000_000,
+        min_temp_entry_ttl: 10,
+    });
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TipContract, ());
+
+    // Deploy a Stellar Asset Contract (token) using the modern API.
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_id = token_contract.address();
+    let fee_recipient = contract_id.clone();
+
+    let t = TestEnv { env, contract_id, admin, fee_recipient, token_id };
+
+    // Initialize contract with the library-default caps and no fee.
+    t.tip_client().init(
+        &t.admin,
+        &t.fee_recipient,
+        &0u32,
+        &crate::DEFAULT_MAX_CREATORS,
+        &crate::DEFAULT_MAX_TIPS_PER_CREATOR,
+        &crate::DEFAULT_MIN_TIP_AMOUNT,
+    );
+}
+
+#[test]
 fn test_init_emits_event() {
     // Use a dedicated env so we can inspect emitted events directly,
     // independent of the shared TestEnv construction path.
@@ -379,6 +419,14 @@ fn test_set_fee_recipient() {
     let new_recipient = Address::generate(&t.env);
     t.tip_client().set_fee_recipient(&t.admin, &new_recipient);
     assert_eq!(t.tip_client().get_fee_recipient(), Some(new_recipient));
+}
+
+#[test]
+#[should_panic(expected = "#12")]
+fn test_set_fee_recipient_contract_address() {
+    let t = TestEnv::new();
+    let new_recipient = env.current_contract_address();
+    t.tip_client().set_fee_recipient(&t.admin, &new_recipient);
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -225,7 +225,7 @@ fn test_init_fee_recipient_is_contract_address() {
     });
 
     let admin = Address::generate(&env);
-    let contract_id = env.register(TipContract, ());
+    let contract_id = env.register_contract(None, TipContract);
 
     // Deploy a Stellar Asset Contract (token) using the modern API.
     let token_admin = Address::generate(&env);
@@ -425,7 +425,7 @@ fn test_set_fee_recipient() {
 #[should_panic(expected = "#12")]
 fn test_set_fee_recipient_contract_address() {
     let t = TestEnv::new();
-    let new_recipient = env.current_contract_address();
+    let new_recipient = t.env.current_contract_address();
     t.tip_client().set_fee_recipient(&t.admin, &new_recipient);
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -51,7 +51,7 @@ impl TestEnv {
 
         let admin = Address::generate(&env);
         let fee_recipient = Address::generate(&env);
-        let contract_id = env.register(TipContract, ());
+        let contract_id = env.register_contract(None, TipContract);
 
         // Deploy a Stellar Asset Contract (token) using the modern API.
         let token_admin = Address::generate(&env);
@@ -94,7 +94,7 @@ impl TestEnv {
 
         let admin = Address::generate(&env);
         let fee_recipient = Address::generate(&env);
-        let contract_id = env.register(TipContract, ());
+        let contract_id = env.register_contract(None, TipContract);
 
         let token_admin = Address::generate(&env);
         let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
@@ -265,7 +265,7 @@ fn test_init_emits_event() {
 
     let admin = Address::generate(&env);
     let fee_recipient = Address::generate(&env);
-    let contract_id = env.register(TipContract, ());
+    let contract_id = env.register_contract(None, TipContract);
     let client = crate::TipContractClient::new(&env, &contract_id);
 
     // Non-default fee bps so the payload cannot accidentally be zero.
@@ -312,7 +312,7 @@ fn test_init_fee_too_high_fails() {
     env.mock_all_auths();
     let admin = Address::generate(&env);
     let fee_recipient = Address::generate(&env);
-    let contract_id = env.register(TipContract, ());
+    let contract_id = env.register_contract(None, TipContract);
     let client = crate::TipContractClient::new(&env, &contract_id);
     client.init(
         &admin,
@@ -425,7 +425,8 @@ fn test_set_fee_recipient() {
 #[should_panic(expected = "#12")]
 fn test_set_fee_recipient_contract_address() {
     let t = TestEnv::new();
-    let new_recipient = t.env.current_contract_address();
+    let new_recipient = t.contract_id.clone();
+
     t.tip_client().set_fee_recipient(&t.admin, &new_recipient);
 }
 
@@ -1013,7 +1014,7 @@ fn test_init_persists_supplied_caps() {
     });
     let admin = Address::generate(&env);
     let fee_recipient = Address::generate(&env);
-    let contract_id = env.register(TipContract, ());
+    let contract_id = env.register_contract(None, TipContract);
     let client = crate::TipContractClient::new(&env, &contract_id);
 
     // Custom caps (not the defaults) are written to storage on init.
@@ -1050,7 +1051,7 @@ fn test_init_supplied_caps_rejects_8th_creator() {
     });
     let admin = Address::generate(&env);
     let fee_recipient = Address::generate(&env);
-    let contract_id = env.register(TipContract, ());
+    let contract_id = env.register_contract(None, TipContract);
     let client = crate::TipContractClient::new(&env, &contract_id);
 
     // Cap of 7, then fill, then attempt an 8th → CapExceeded.
@@ -1081,7 +1082,7 @@ fn test_init_with_zero_caps_means_unlimited() {
     });
     let admin = Address::generate(&env);
     let fee_recipient = Address::generate(&env);
-    let contract_id = env.register(TipContract, ());
+    let contract_id = env.register_contract(None, TipContract);
     let client = crate::TipContractClient::new(&env, &contract_id);
 
     // `0` = unlimited for both caps; `0` also disables the minimum.
@@ -1608,7 +1609,7 @@ fn test_min_tip_amount_negative_init_fails() {
     });
     let admin = Address::generate(&env);
     let fee_recipient = Address::generate(&env);
-    let contract_id = env.register(TipContract, ());
+    let contract_id = env.register_contract(None, TipContract);
     let client = crate::TipContractClient::new(&env, &contract_id);
     client.init(
         &admin,


### PR DESCRIPTION
## Description

Prevent fee-routing loop: reject fee_recipient == contract address
closes #67 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI / build improvements

## How Has This Been Tested?

- [x] `cargo test` passes
- [x] `cargo clippy` shows no warnings
- [x] `cargo fmt -- --check` passes
- [x] `cargo build --release --target wasm32-unknown-unknown` succeeds

## Checklist:

- [x] My code follows the style guidelines of this project (`cargo fmt`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (`cargo clippy`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
