### PR TITLE
test: characterize rebasing-token behaviour with a SEP-41 fixture

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,7 +64,7 @@ This section documents a STRIDE threat model for the current contract (`CONTRACT
 **Trust boundaries**
 
 - Wallet authorization: every state-changing function calls `require_auth()` on the acting address; the contract performs no signature verification of its own.
-- External calls: token movements go through Stellar Asset Contract (SAC) `token::Client` transfers — the token contracts are outside this contract's trust domain.
+- External calls: token movements go through Stellar Asset Contract (SAC) `token::Client` transfers — the token contracts are outside this contract's trust domain, and the contract assumes only that a transfer of `amount` moves `amount`; it does not verify this and does not reconcile its internal ledger against token balances (see Residual Risks).
 - Storage tiers: instance storage (shared config) vs. persistent storage (per-creator data) have independent TTL lifecycles.
 
 ### STRIDE Table
@@ -77,6 +77,7 @@ This section documents a STRIDE threat model for the current contract (`CONTRACT
 | Fee arithmetic overflow or precision manipulation | Tampering | `tip()` fee calculation | `overflow-checks = true` in the release profile, `i128` arithmetic, multiply-before-divide, and fuzz-tested invariants (10,000 proptest cases) | [#43](https://github.com/StellarTips/StellarTip-Contract/issues/43) |
 | Tip proceeds routed against corrupted fee state (fee set, recipient missing) | Tampering | `tip()` | Fail-fast `FeeRecipientNotSet` guard evaluated before any external transfer | [#28](https://github.com/StellarTips/StellarTip-Contract/issues/28) (PR [#46](https://github.com/StellarTips/StellarTip-Contract/pull/46)) |
 | Withdrawing more than the accrued balance | Tampering | `withdraw()` | `current_balance >= amount` check before any SAC call; violation panics `InsufficientBalance` | Initial design (v0.1.0) |
+| Non-standard token breaking the custody invariant (rebasing, fee-on-transfer, clawback) | Tampering | `tip()` and `withdraw()` SAC calls | **Accepted, not mitigated.** Internal `Balance(creator, token)` bookkeeping is authoritative and is never reconciled against `token.balance()`; divergence is confined to the offending token. Characterised by a rebasing-token fixture in `src/fixtures.rs` | [#85](https://github.com/StellarTips/StellarTip-Contract/issues/85) |
 | State changes without an audit trail | Repudiation | All state-changing functions | Every state-changing function emits a typed event (`EVENT_*`); the missing `init()` event was fixed | [#31](https://github.com/StellarTips/StellarTip-Contract/issues/31) (PR [#47](https://github.com/StellarTips/StellarTip-Contract/pull/47)) |
 | Disputing that a tip occurred | Repudiation | `tip()` | Tip records are written to persistent storage as permanent on-chain history | Initial design (v0.1.0) |
 | Reading contract state (balances, profiles, history) | Information disclosure | All storage | All contract state is public on-chain **by design**; no secrets are stored. Accepted property, not a gap | — |
@@ -96,6 +97,11 @@ This section documents a STRIDE threat model for the current contract (`CONTRACT
 - **Single admin key.** There is no multisig or timelock. A compromised admin key enables pause abuse and fee redirection. Fee redirection is bounded: `fee_bps` is capped at 10,000 (100%) and applies only to **future** tips — existing creator balances can only ever be withdrawn by the creator.
 - **Unbounded `limit` in `get_tips()`.** Documented as M-2 in [`docs/static-analysis-findings.md`](docs/static-analysis-findings.md). Impact is limited to instruction-budget exhaustion of the caller's own read; no state risk.
 - **`DEFAULT_MIN_TIP_AMOUNT = 1` provides no real dust protection.** It is equivalent to the `amount > 0` guard. Admins must raise it via `set_min_tip_amount` post-deploy for meaningful protection.
+- **The custody invariant is implicit and unenforced.** The contract relies on `sum(internal balances for token T) == T.balance(contract)` but never checks it: `tip()` credits the `amount` argument and `withdraw()` debits it, and neither reads `token.balance()`. Any token that moves holder balances outside a transfer breaks the invariant — **rebasing** tokens (stETH, aTokens), **fee-on-transfer** tokens (the contract receives less than `amount` but credits the full `amount`), and tokens with **clawback** enabled. All three are legal SEP-41 tokens.
+
+  Consequences are bounded to the offending token and are published behaviour, not latent bugs. An upward rebase strands surplus in the contract permanently — there is no sweep function. A downward rebase leaves the contract under-collateralised: withdrawals revert *inside the token contract* rather than with a `TipError`, and the last creators to withdraw absorb the shortfall. A wipeout leaves `unregister()` blocked by `BalanceNotEmpty`, since internal credit survives a token balance going to zero.
+
+  Choosing which tokens to accept is the supporter's and the creator's responsibility. The rebasing case is characterised by the fixture in `src/fixtures.rs` and the tests in `src/test.rs`; a fee-on-transfer fixture is worth a follow-up issue.
 
 ### Review Cadence
 

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -1,0 +1,194 @@
+#![cfg(test)]
+//! Test-only token fixtures.
+//!
+//! # `RebasingToken`
+//!
+//! A minimal but *conforming* SEP-41 token whose holder balances change
+//! without any transfer — the defining property of stETH, Aave aTokens and
+//! friends. Holders own **shares**; the nominal balance reported by
+//! `balance()` is `shares * num / den`, and `rebase(num, den)` rescales every
+//! holder at once without moving a single share.
+//!
+//! It exists to characterise what `TipContract` does when the invariant
+//!
+//! ```text
+//! sum(internal balances for token T) == T.balance(contract)
+//! ```
+//!
+//! stops holding. `TipContract` credits `Balance(creator, token)` straight
+//! from the `amount` argument and never reads `token.balance()`, so a rebase
+//! silently desynchronises the two ledgers. See the rebasing-token section of
+//! `src/test.rs` and the Residual Risks entry in `SECURITY.md`.
+//!
+//! ## Why the full `TokenInterface` trait
+//!
+//! The claim being pinned down is that *a rebasing token is a legal token*.
+//! An inherent impl would assert that in a comment; implementing the trait
+//! asserts it to the compiler — this fixture does not build unless it presents
+//! a complete conforming interface. The five methods `TipContract` never calls
+//! panic `NotSupported`, which doubles as a standing audit of the contract's
+//! actual token surface: today it uses `transfer` and nothing else.
+//!
+//! ## Constraints callers must respect
+//!
+//! - **Use only the exact rebase factors `(1,1)`, `(2,1)`, `(1,2)` and
+//!   `(0,1)`, with amounts that are multiples of 2.** Every arithmetic step is
+//!   then exact and no assertion depends on truncation. Picking something like
+//!   `(3,7)` will produce confusing off-by-one results that are artifacts of
+//!   this mock, not of `TipContract`.
+//! - **Keep amounts small (≤ 10_000).** `amount * den` is unguarded and can
+//!   overflow `i128` for adversarial inputs. Guarding it would add arithmetic
+//!   that the tests do not exercise.
+//!
+//! Error codes start at 900 so they can never collide with a `TipError`
+//! (1–16). A `#[should_panic(expected = "#900")]` therefore *positively
+//! proves* a revert came from the token layer, after `TipContract`'s own
+//! guards passed.
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, token::TokenInterface,
+    Address, Env, String,
+};
+
+/// Storage keys for `RebasingToken`.
+#[contracttype]
+#[derive(Clone)]
+pub enum RebasingKey {
+    /// Shares held by an address. Nominal balance is `shares * num / den`.
+    Shares(Address),
+    /// Rebase numerator.
+    Num,
+    /// Rebase denominator.
+    Den,
+}
+
+/// Failures raised by `RebasingToken`. Numbered from 900 to stay clear of
+/// `TipError` (1–16) so tests can attribute a panic to the token layer.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum RebasingTokenError {
+    /// Holder does not own enough shares to cover the transfer.
+    InsufficientBalance = 900,
+    /// A conforming method that this fixture deliberately does not implement.
+    /// Reaching it means `TipContract` grew a new token dependency.
+    NotSupported = 901,
+    /// `den <= 0`, or `num < 0`, or a share conversion attempted while
+    /// `num == 0` (a wiped-out token).
+    InvalidRebaseFactor = 902,
+}
+
+#[contract]
+pub struct RebasingToken;
+
+/// Test knobs. Kept in their own `impl` block so the conforming SEP-41
+/// surface below stays visually separate from the fixture's controls.
+#[contractimpl]
+impl RebasingToken {
+    /// Credit `to` with `amount` *nominal* units at the current rebase factor.
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let shares = nominal_to_shares(&env, amount);
+        let current = shares_of(&env, &to);
+        env.storage().persistent().set(&RebasingKey::Shares(to), &(current + shares));
+    }
+
+    /// Rescale every holder's nominal balance to `shares * num / den` without
+    /// moving any shares. `rebase(0, 1)` wipes the token out.
+    pub fn rebase(env: Env, num: i128, den: i128) {
+        if num < 0 || den <= 0 {
+            panic_with_error!(&env, RebasingTokenError::InvalidRebaseFactor);
+        }
+        env.storage().instance().set(&RebasingKey::Num, &num);
+        env.storage().instance().set(&RebasingKey::Den, &den);
+    }
+}
+
+#[contractimpl]
+impl TokenInterface for RebasingToken {
+    fn balance(env: Env, id: Address) -> i128 {
+        let (num, den) = factor(&env);
+        shares_of(&env, &id) * num / den
+    }
+
+    /// Moves `amount` **nominal** units, converting to shares internally —
+    /// exactly what a real rebasing token does. Moving shares instead would
+    /// mean `tip(1000)` credited 1000 internally while transferring some other
+    /// nominal amount, and the divergence under test would be an artifact of a
+    /// wrong mock rather than of rebasing.
+    fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+
+        // Convert once and compare in share-space. Checking sufficiency in
+        // nominal-space and deducting in share-space is two independent
+        // truncations, and inputs exist where the check passes but the
+        // deduction underflows.
+        let shares = nominal_to_shares(&env, amount);
+        let from_shares = shares_of(&env, &from);
+        if from_shares < shares {
+            panic_with_error!(&env, RebasingTokenError::InsufficientBalance);
+        }
+
+        let to_shares = shares_of(&env, &to);
+        env.storage().persistent().set(&RebasingKey::Shares(from), &(from_shares - shares));
+        env.storage().persistent().set(&RebasingKey::Shares(to), &(to_shares + shares));
+    }
+
+    fn decimals(_env: Env) -> u32 {
+        7
+    }
+
+    fn name(env: Env) -> String {
+        String::from_str(&env, "Rebasing")
+    }
+
+    fn symbol(env: Env) -> String {
+        String::from_str(&env, "REBASE")
+    }
+
+    // -----------------------------------------------------------------------
+    // Unsupported: `TipContract` calls none of these. Leave them panicking —
+    // if one ever fires, the contract's token dependency has widened.
+    // -----------------------------------------------------------------------
+
+    fn allowance(env: Env, _from: Address, _spender: Address) -> i128 {
+        panic_with_error!(&env, RebasingTokenError::NotSupported)
+    }
+
+    fn approve(env: Env, _from: Address, _spender: Address, _amount: i128, _expiration: u32) {
+        panic_with_error!(&env, RebasingTokenError::NotSupported)
+    }
+
+    fn transfer_from(env: Env, _spender: Address, _from: Address, _to: Address, _amount: i128) {
+        panic_with_error!(&env, RebasingTokenError::NotSupported)
+    }
+
+    fn burn(env: Env, _from: Address, _amount: i128) {
+        panic_with_error!(&env, RebasingTokenError::NotSupported)
+    }
+
+    fn burn_from(env: Env, _spender: Address, _from: Address, _amount: i128) {
+        panic_with_error!(&env, RebasingTokenError::NotSupported)
+    }
+}
+
+/// Current `(num, den)`. Defaults to `(1, 1)` — a freshly deployed token has
+/// not rebased, so nominal balance equals shares.
+fn factor(env: &Env) -> (i128, i128) {
+    let num: i128 = env.storage().instance().get(&RebasingKey::Num).unwrap_or(1);
+    let den: i128 = env.storage().instance().get(&RebasingKey::Den).unwrap_or(1);
+    (num, den)
+}
+
+fn shares_of(env: &Env, id: &Address) -> i128 {
+    env.storage().persistent().get(&RebasingKey::Shares(id.clone())).unwrap_or(0)
+}
+
+/// `amount` nominal units expressed in shares. Guards `num == 0` so a wipeout
+/// rebase raises `InvalidRebaseFactor` rather than a raw host divide-by-zero.
+fn nominal_to_shares(env: &Env, amount: i128) -> i128 {
+    let (num, den) = factor(env);
+    if num == 0 {
+        panic_with_error!(env, RebasingTokenError::InvalidRebaseFactor);
+    }
+    amount * den / num
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -892,6 +892,9 @@ impl TipContract {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+mod fixtures;
+
+#[cfg(test)]
 mod test;
 
 #[cfg(test)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,7 +8,10 @@ use soroban_sdk::{
 };
 use token::Client as TokenClient;
 
-use crate::TipContract;
+use crate::{
+    fixtures::{RebasingToken, RebasingTokenClient},
+    TipContract,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -154,6 +157,15 @@ impl TestEnv {
         sac.mint(&self.admin, &1_000_000_000);
         let client = TokenClient::new(&self.env, &id);
         (id, client, sac)
+    }
+
+    /// Deploy a `RebasingToken` fixture. Returns its address and a client.
+    /// The token starts at rebase factor (1, 1), so it behaves like an
+    /// ordinary token until a test calls `rebase`.
+    fn deploy_rebasing_token(&self) -> (Address, RebasingTokenClient<'_>) {
+        let id = self.env.register_contract(None, RebasingToken);
+        let client = RebasingTokenClient::new(&self.env, &id);
+        (id, client)
     }
 
     /// Deploy `count` additional Stellar asset tokens and mint the admin a
@@ -1652,4 +1664,143 @@ fn test_min_tip_amount_negative_setter_fails() {
 fn test_contract_version_is_3() {
     let t = TestEnv::new();
     assert_eq!(t.tip_client().get_contract_version(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Rebasing / non-standard token characterization tests (issue #85)
+// ---------------------------------------------------------------------------
+//
+// These tests do not assert a defence. They pin down and publish an accepted
+// property: `TipContract` credits `Balance(creator, token)` from the `amount`
+// argument and never reconciles it against `token.balance()`, so the invariant
+// `sum(internal balances for T) == T.balance(contract)` is implicit and
+// unenforced. A rebasing token — a legal SEP-41 token — breaks it silently.
+//
+// What the suite establishes: internal bookkeeping stays authoritative,
+// divergence is confined to the offending token, and the consequences (stranded
+// surplus, under-collateralisation, a wipeout that still blocks `unregister`)
+// are known rather than surprising. Choosing which tokens to accept is the
+// supporter's and creator's responsibility. See `SECURITY.md`.
+//
+// The fee path is deliberately untested here: that the fee recipient's balance
+// rebases is a property of the fixture, not of `TipContract`. The genuinely
+// contract-relevant sibling is *fee-on-transfer*, which needs its own fixture.
+
+/// Register `alice`, fund `bob` on a fresh `RebasingToken`, and tip 1_000 at
+/// the default (1, 1) factor. Returns the token address and its client.
+fn seed_rebasing_tip<'a>(
+    t: &'a TestEnv,
+    alice: &Address,
+    bob: &Address,
+) -> (Address, RebasingTokenClient<'a>) {
+    let (token_id, token) = t.deploy_rebasing_token();
+    t.tip_client().register(alice, &Symbol::new(&t.env, "alice"), &s(&t.env, "A"), &s(&t.env, ""));
+    token.mint(bob, &10_000);
+    t.tip_client().tip(bob, alice, &token_id, &1_000, &s(&t.env, ""));
+    (token_id, token)
+}
+
+#[test]
+fn test_rebasing_token_does_not_affect_internal_balance() {
+    let t = TestEnv::new();
+    let alice = Address::generate(&t.env);
+    let bob = Address::generate(&t.env);
+    let (token_id, token) = seed_rebasing_tip(&t, &alice, &bob);
+
+    assert_eq!(t.tip_client().get_balance(&alice, &token_id), 1_000);
+    assert_eq!(token.balance(&t.contract_id), 1_000);
+
+    // Doubling rebase: the token says the contract holds 2_000, the internal
+    // ledger is untouched.
+    token.rebase(&2, &1);
+    assert_eq!(token.balance(&t.contract_id), 2_000);
+    assert_eq!(t.tip_client().get_balance(&alice, &token_id), 1_000);
+
+    // Halving rebase: the token says 500, the internal ledger still says 1_000.
+    token.rebase(&1, &2);
+    assert_eq!(token.balance(&t.contract_id), 500);
+    assert_eq!(t.tip_client().get_balance(&alice, &token_id), 1_000);
+}
+
+#[test]
+#[should_panic(expected = "#900")]
+fn test_rebasing_token_downward_rebase_makes_withdraw_fail_at_token_layer() {
+    let t = TestEnv::new();
+    let alice = Address::generate(&t.env);
+    let bob = Address::generate(&t.env);
+    let (token_id, token) = seed_rebasing_tip(&t, &alice, &bob);
+
+    token.rebase(&1, &2);
+
+    // The internal ledger still credits alice 1_000, so TipContract's own
+    // InsufficientBalance (#4) guard passes. The revert comes from the token:
+    // #900 proves it happened below the contract, not inside it.
+    t.tip_client().withdraw(&alice, &token_id, &1_000);
+}
+
+#[test]
+fn test_rebasing_token_downward_rebase_still_permits_partial_withdraw() {
+    let t = TestEnv::new();
+    let alice = Address::generate(&t.env);
+    let bob = Address::generate(&t.env);
+    let (token_id, token) = seed_rebasing_tip(&t, &alice, &bob);
+
+    token.rebase(&1, &2);
+    t.tip_client().withdraw(&alice, &token_id, &500);
+
+    // Alice received the full 500 nominal and the contract is drained...
+    assert_eq!(token.balance(&alice), 500);
+    assert_eq!(token.balance(&t.contract_id), 0);
+    // ...yet the internal ledger still promises her another 500. This is the
+    // sharpest statement of the risk: unbacked internal credit.
+    assert_eq!(t.tip_client().get_balance(&alice, &token_id), 500);
+}
+
+#[test]
+fn test_rebasing_token_upward_rebase_strands_surplus_in_contract() {
+    let t = TestEnv::new();
+    let alice = Address::generate(&t.env);
+    let bob = Address::generate(&t.env);
+    let (token_id, token) = seed_rebasing_tip(&t, &alice, &bob);
+
+    token.rebase(&2, &1);
+    t.tip_client().withdraw(&alice, &token_id, &1_000);
+
+    // Alice gets exactly her internal credit and the ledger closes out.
+    assert_eq!(token.balance(&alice), 1_000);
+    assert_eq!(t.tip_client().get_balance(&alice, &token_id), 0);
+    assert_eq!(t.tip_client().get_all_tokens(&alice).len(), 0);
+    // The other 1_000 is permanently stranded — there is no sweep function.
+    assert_eq!(token.balance(&t.contract_id), 1_000);
+}
+
+#[test]
+fn test_rebasing_token_wipeout_does_not_unblock_unregister() {
+    let t = TestEnv::new();
+    let alice = Address::generate(&t.env);
+    let bob = Address::generate(&t.env);
+    let (token_id, token) = seed_rebasing_tip(&t, &alice, &bob);
+
+    token.rebase(&0, &1);
+
+    assert_eq!(token.balance(&t.contract_id), 0);
+    // Internal credit and the tracked token set are untouched by the wipeout.
+    assert_eq!(t.tip_client().get_balance(&alice, &token_id), 1_000);
+    assert_eq!(t.tip_client().get_all_tokens(&alice).len(), 1);
+}
+
+#[test]
+#[should_panic(expected = "#13")]
+fn test_rebasing_token_wipeout_unregister_fails() {
+    let t = TestEnv::new();
+    let alice = Address::generate(&t.env);
+    let bob = Address::generate(&t.env);
+    let (_token_id, token) = seed_rebasing_tip(&t, &alice, &bob);
+
+    token.rebase(&0, &1);
+
+    // BalanceNotEmpty still pins the profile even though the token reports
+    // zero. The one case where "internal bookkeeping is authoritative" is
+    // protective rather than harmful.
+    t.tip_client().unregister(&alice);
 }


### PR DESCRIPTION
# Closes #85 

## test: Rebasing Token Characterization Tests and Threat-Model Entry ([#85](#))

### Description

`TipContract` credits `Balance(creator, token)` straight from the `amount` argument passed to `tip()` and never reads `token.balance()`. That leaves an invariant implicit and unenforced:

```
sum(internal balances for token T) == T.balance(contract)
```

A rebasing token — stETH, Aave aTokens — is a perfectly legal SEP-41 token whose holder balances change without any transfer. Point one at this contract and the invariant breaks silently: the contract keeps reporting internal credit that the token no longer backs.

This PR does not defend against that. It pins the behaviour down and publishes it: internal bookkeeping is authoritative, divergence is confined to the offending token, and choosing which tokens to accept is the supporter's and creator's responsibility.

**No contract logic changed.** The deliverable is a fixture, characterization tests, and a threat-model entry.

---

### `src/fixtures.rs` — New File

`RebasingToken` — holders own shares; nominal balance is `shares * num / den`. `rebase(num, den)` rescales every holder at once without moving shares, which is exactly the property that breaks the invariant.

**Two design choices worth reviewer attention:**

- **Full `TokenInterface` trait impl, not an inherent impl.** The thesis of the issue is that a rebasing token is legal. An inherent impl asserts that in a comment; the trait impl asserts it to the compiler — the fixture will not build unless it presents a complete conforming interface. The five methods `TipContract` never calls (`allowance`, `approve`, `transfer_from`, `burn`, `burn_from`) panic `NotSupported`, which doubled as a free audit: the contract touches `transfer` and nothing else (`src/lib.rs:653`, `:663`, `:733`). If one of those panics ever fires, the token dependency has widened.
- **Error codes start at 900** (`InsufficientBalance = 900`, `NotSupported = 901`, `InvalidRebaseFactor = 902`) so they can never collide with a `TipError` (1–16). This is what makes the `#900` assertion proof rather than suggestion.

**Two implementation details are load-bearing:**

- `transfer` moves nominal amounts, not shares, converting internally like real rebasing tokens. Moving shares would mean `tip(1000)` credits `1000` internally while transferring some other nominal amount, and the divergence under test would be an artifact of a wrong mock rather than of rebasing.
- Nominal→shares conversion happens exactly once, and sufficiency is compared in share-space. Checking in nominal-space and deducting in share-space is two independent truncations, and inputs exist where the check passes but the deduction underflows.

---

### `src/test.rs`

`TestEnv::deploy_rebasing_token()` plus a new banner section with 6 tests:

| Test | Establishes |
|------|-------------|
| `..._does_not_affect_internal_balance` | Tip `1000`; `rebase(2,1)` → token says `2000`, `get_balance` still `1000`. `rebase(1,2)` → token says `500`, `get_balance` still `1000`. This is AC #2. |
| `..._downward_rebase_makes_withdraw_fail_at_token_layer` | `#[should_panic("#900")]` — after halving, withdrawing the full `1000` passes `TipContract`'s `#4` guard and reverts inside the token |
| `..._downward_rebase_still_permits_partial_withdraw` | After halving, withdrawing `500` succeeds and drains the contract to `0`, leaving `500` of unbacked internal credit. Sharpest statement of the risk. |
| `..._upward_rebase_strands_surplus_in_contract` | After doubling and a full withdraw, alice gets `1000`, `get_all_tokens` empties, and `1000` is permanently stranded — there is no sweep function |
| `..._wipeout_does_not_unblock_unregister` | `rebase(0,1)` → token balance `0`, but internal credit and the token set are untouched |
| `..._wipeout_unregister_fails` | `#[should_panic("#13")]` — `BalanceNotEmpty` still pins the profile. The one case where "internal bookkeeping is authoritative" is protective |

Tests 5/6 and 2/3 are split because `#[should_panic]` swallows any assertion after the panic.

Rebase factors are pinned to `(1,1)`, `(2,1)`, `(1,2)`, `(0,1)` with amount `1000` so every arithmetic step is exact and no assertion depends on truncation. That constraint is documented in the fixture doc comment so nobody later picks `(3,7)` and gets a confusing off-by-one.

The fee path is deliberately untested — that the fee recipient's balance rebases is a property of the fixture, not of `TipContract`. The genuinely contract-relevant sibling failure is fee-on-transfer, which deserves its own fixture (see follow-up below).

---

### `SECURITY.md`

Three additions per the Review Cadence rule:

1. **STRIDE row** under Tampering, placed after "Withdrawing more than the accrued balance". The mitigation cell opens with bold **Accepted, not mitigated** — a deliberate break from the other rows' voice so it cannot skim as a defence.
2. **Residual and Accepted Risks bullet** covering rebasing, fee-on-transfer, and clawback, spelling out the three consequences: upward rebase strands unrecoverable surplus; downward rebase leaves the contract under-collateralised so withdrawals revert inside the token rather than with a `TipError` and the last creators absorb the shortfall; wipeout leaves `unregister()` blocked by `BalanceNotEmpty`.
3. **Trust boundaries clause** extending "token contracts are outside this contract's trust domain" with the assumption that a transfer of `amount` moves `amount` — unverified and unreconciled.

`Cargo.toml` is not touched. `CONTRACT_VERSION` stays at `3`.

---

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] CI / build improvements

---

### Testing

- [x] `cargo test` — **82 passed, 0 failed** (76 pre-existing + 6 new), 1312s including 30,000 proptest cases
- [x] `cargo clippy` — no warnings (`--target wasm32-unknown-unknown --release -- -D warnings`). The `NotSupported` variant did not trigger dead-code, so no `#[allow(dead_code)]` was needed
- [x] `cargo fmt -- --check` passes
- [x] `cargo build --release --target wasm32-unknown-unknown` succeeds

**The compiled WASM is byte-identical to `main`:** 25,106 bytes on both. Everything added is `#[cfg(test)]`-gated, so any size delta would mean fixture code had leaked into the deployed contract.

**The `#900` assertion was verified non-vacuous.** Temporarily inverting the expected code dumped the host event log, showing the exact causal chain:

```
9:  fn_call  withdraw  [alice, token, 1000]
8:  fn_call  transfer  [contract, alice, 1000]
7:  error    "failing with contract error", 900
```

The revert genuinely originates in the token layer, after `TipContract`'s own `InsufficientBalance` guard passed.

**Not run locally:** `cargo scout-audit` — the binary is not installed. CI covers it via `coinfabrik/scout-actions` with `fail_on_error: true`.

---

### Deviation from AC #1

The acceptance criteria ask for the fixture under `tests/fixtures/`. It is at `src/fixtures.rs` instead.

The crate is `crate-type = ["cdylib"]`. A `tests/` integration directory cannot link against it without also adding `"rlib"` to `Cargo.toml`, and `TestEnv` is private to `src/test.rs`, so the whole harness would have to be duplicated. `src/fixtures.rs` matches the existing `test.rs` / `fuzz.rs` convention and needs zero `Cargo.toml` change.

If the `tests/` layout matters more than avoiding the `rlib` addition, say so and it can be moved.

---

### Notes for Reviewers

- **`CONTRACT_VERSION` deliberately unchanged.** No function, storage key, or `init()` signature changed, so the `SECURITY.md` Review Cadence rule is satisfied by the threat-model update alone. The byte-identical WASM backs this up.
- **Suggested follow-up:** a fee-on-transfer fixture — the contract receives less than `amount` but credits the full `amount`. Out of scope here; named in the new `SECURITY.md` bullet.
- **`src/test.rs`, `seed_rebasing_tip`** — written with a placeholder stub mid-draft and corrected before the first compile. Worth a specific glance in review.
- Snapshot files under `test_snapshots/` are generated by the new tests and are gitignored; none are committed.

---

### Checklist

- [x] Code follows the style guidelines of this project (`cargo fmt`)
- [x] Self-review performed
- [x] Hard-to-understand areas commented
- [x] Corresponding documentation changes made
- [x] No new warnings (`cargo clippy`)
- [x] Tests prove the feature works
- [x] New and existing unit tests pass locally
