### PR TITLE
ci(coverage): add cargo-llvm-cov gate with ≥ 85% line threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,44 @@ jobs:
         with:
           name: scout-report
           path: report.md
+
+  coverage:
+    name: Coverage (≥ 85%)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: llvm-tools-preview
+
+      # Pin the same ed25519-dalek version used in the test job to avoid
+      # soroban-env-host / rand_core incompatibilities.
+      - name: Pin ed25519-dalek to 2.2.0
+        run: |
+          cargo update -p ed25519-dalek@2.2.0 --precise 2.2.0 || true
+          cargo update -p ed25519-dalek@3.0.0 --precise 2.2.0 || true
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov@0.6.14
+
+      - name: Run tests with coverage instrumentation
+        run: |
+          cargo llvm-cov \
+            --lcov \
+            --output-path lcov.info
+
+      - name: Enforce ≥ 85% line coverage
+        run: |
+          cargo llvm-cov report \
+            --fail-under-lines 85
+
+      - name: Upload coverage report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: lcov.info


### PR DESCRIPTION
## Summary

Implemented a production-ready fix while maintaining the existing architecture and coding standards.

### Changes

- Added a new `coverage` CI job that installs `cargo-llvm-cov@0.6.14` via `taiki-e/install-action`
- Runs the full test suite with LLVM source-based coverage instrumentation
- Enforces ≥ 85% total line coverage via `cargo llvm-cov report --fail-under-lines 85` — the job fails if coverage drops below the threshold
- Uploads `lcov.info` as a CI artifact so reviewers and contributors can inspect per-file coverage without running locally
- Pins `ed25519-dalek` to 2.2.0 in the coverage job (mirrors the existing `test` job workaround) to avoid `soroban-env-host` build failures
- Verified linting
- Verified build
- Ensured no unrelated changes were introduced

Closes #94