### PR TITLE
feat(dx): add make interact-testnet driver script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean fmt lint check scout wasm-build doc deploy-testnet deploy-mainnet
+.PHONY: build test clean fmt lint check scout wasm-build doc deploy-testnet deploy-mainnet interact-testnet
 
 build:
 	cargo build --release
@@ -32,3 +32,9 @@ deploy-testnet:
 
 deploy-mainnet:
 	./scripts/deploy.sh mainnet
+
+## Invoke a function on the deployed testnet contract.
+## Usage: make interact-testnet FN=get_contract_version
+##        make interact-testnet FN=get_profile ARGS="--address GABC..."
+interact-testnet:
+	./scripts/interact.sh $(FN) $(ARGS)

--- a/scripts/interact.sh
+++ b/scripts/interact.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# StellarTip Contract — Interaction Driver (testnet)
+#
+# Usage:
+#   ./scripts/interact.sh <function_name> [arg1 arg2 ...]
+#
+# The script reads the deployed contract ID from the CONTRACT_ID environment
+# variable or from .contract-id (written by scripts/deploy.sh). It then
+# invokes the given function on the StellarTip contract on Stellar testnet
+# using the Stellar CLI and prints the result in human-readable form.
+#
+# Examples:
+#   ./scripts/interact.sh get_contract_version
+#   ./scripts/interact.sh is_paused
+#   ./scripts/interact.sh get_creator_count
+#   ./scripts/interact.sh get_profile --address GABC123...
+#   ./scripts/interact.sh tip \
+#       --creator GABC123... \
+#       --token CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC \
+#       --amount 1000000 \
+#       --message "great content!"
+#
+# Environment variables:
+#   CONTRACT_ID   – Soroban contract address (overrides .contract-id file)
+#   NETWORK       – Stellar network to use (default: testnet)
+#   IDENTITY      – Stellar CLI identity to sign with (default: default)
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve configuration
+# ---------------------------------------------------------------------------
+
+NETWORK="${NETWORK:-testnet}"
+IDENTITY="${IDENTITY:-default}"
+CONTRACT_ID_FILE=".contract-id"
+
+# Require at least one argument (the function name)
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <function_name> [arg1 arg2 ...]" >&2
+  echo "       CONTRACT_ID=<id> $0 <function_name> [arg1 arg2 ...]" >&2
+  exit 1
+fi
+
+FUNCTION_NAME="$1"
+shift  # remaining args are passed through to the CLI
+
+# ---------------------------------------------------------------------------
+# Preflight: Stellar CLI
+# ---------------------------------------------------------------------------
+
+if ! command -v stellar &>/dev/null; then
+  echo "Error: 'stellar' CLI not found." >&2
+  echo "Install it with: cargo install stellar-cli --locked" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve contract ID
+# ---------------------------------------------------------------------------
+
+if [[ -z "${CONTRACT_ID:-}" ]]; then
+  if [[ -f "$CONTRACT_ID_FILE" ]]; then
+    CONTRACT_ID="$(cat "$CONTRACT_ID_FILE")"
+    CONTRACT_ID="${CONTRACT_ID//[[:space:]]/}"  # strip whitespace
+  else
+    echo "Error: CONTRACT_ID is not set and '$CONTRACT_ID_FILE' does not exist." >&2
+    echo "Deploy the contract first ('make deploy-testnet') or set CONTRACT_ID." >&2
+    exit 1
+  fi
+fi
+
+if [[ -z "$CONTRACT_ID" ]]; then
+  echo "Error: CONTRACT_ID is empty." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Invoke the function
+# ---------------------------------------------------------------------------
+
+echo "Network  : $NETWORK"
+echo "Contract : $CONTRACT_ID"
+echo "Function : $FUNCTION_NAME"
+[[ $# -gt 0 ]] && echo "Args     : $*"
+echo "---"
+
+stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --network "$NETWORK" \
+  --source "$IDENTITY" \
+  -- \
+  "$FUNCTION_NAME" \
+  "$@"
+
+echo ""
+echo "Done."


### PR DESCRIPTION
## Summary

Implemented a production-ready fix while maintaining the existing architecture and coding standards.

### Changes

- Added `scripts/interact.sh` — a bash driver that invokes any StellarTip contract function on testnet via `stellar contract invoke`
- Script reads the deployed contract ID from `CONTRACT_ID` env var or `.contract-id` file (written by `scripts/deploy.sh`)
- Validates that the `stellar` CLI is installed before proceeding
- Accepts any function name and forwards extra arguments unchanged to the CLI
- Prints network, contract, function, and args for easy audit
- Uses `set -euo pipefail` for safe error handling
- Added `interact-testnet` target to the `Makefile` using `FN` and `ARGS` variables
- Updated `.PHONY` list
- Verified linting
- Verified build
- Ensured no unrelated changes were introduced

**Usage:**
```bash
make interact-testnet FN=get_contract_version
make interact-testnet FN=is_paused
make interact-testnet FN=get_profile ARGS='--address GABC123...'
CONTRACT_ID=C... make interact-testnet FN=get_creator_count
```

Closes #110